### PR TITLE
Moving User to IlluminateUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# laravel-recommendation
+# Laravel Recommendation
 
 > This package provides to generate user unique code with Laravel.
 
@@ -6,100 +6,79 @@
 
 Currently this package only for laravel 5.5.
 
-Install by composer
+### Install via composer
 ```
     $ composer require tsubasarcs/laravel-recommendation
 ```
 
-Registering Aliases
+### Register Alias
 
-You should put aliases 'Code' to `app.php`.
+You need to alias `Code` in `app.php`.
 
 ``` php
-<?php
-
 //app.php
-    
     'aliases' => [
         'Code' => \Tsubasarcs\Recommendations\Facades\Code::class,
     ],
 ```
 
-Run the following on your terminal to publish the migrations:
+Run the following to publish the migrations on your terminal:
 ``` bash
     $ php artisan vendor:publish --provider="Tsubasarcs\Recommendations\RecommendationServiceProvider" --tag="migrations"
 ```
 
-If you want to change some parameter, you can run the following on your terminal to publish the config:
+If you want to change some parameters, you can run the following to publish the config on your terminal:
 ``` bash
     $ php artisan vendor:publish --provider="Tsubasarcs\Recommendations\RecommendationServiceProvider" --tag="config"
 ```
 
 # Set Config
-Prevent code repeat, will check default Recommendation Model "code" column, if you want to custom model and column.
+If you want to do customize model and column, please check Recommendation Model "code" column to prevent code duplicate.
 ``` php
-<?php
-
 // config/recommendation.php
 ...
     'model' => [
         'name' => \Tsubasarcs\Recommendations\Recommendation::class,
         'code_column' => 'code',
     ],
-
 ```
-Model Recommendation is default belongs to \Tsubasarcs\Recommendations\Tests\Illuminate\User::class,
-You should change it to your application model.
+Model Recommendation is default belongs to `\Tsubasarcs\Recommendations\IlluminateUser::class`,
+You need to change it to your application model.
 
 ``` php
-<?php
-
 // config/recommendation.php
 ...
-    'relation_model' => \Tsubasarcs\Recommendations\Tests\Illuminate\User::class,
-
+    'relation_model' => \Tsubasarcs\Recommendations\IlluminateUser::class,
 ```
 
-Generate Code default type and length attribute can custom.
+Generating Code type and length attributes can be customize via setting default key value.
 
 ``` php
-<?php
-
 // config/recommendation.php
 ...
     'default' => [
         'type' => 1,
         'length' => 10,
     ],
-
 ```
 
 # Usage
-## Generate Code
-Code Facade end point is generate(), it always return an array.
+## Generating Code
+Code Facade end point is `generate()`, it will return an array.
 
 ```php
-<?php
-
     Code::generate(); 
     // [['type' => 1,'code' => 'X6nbxJ8DHk']];
-
 ```
 
-If you are not use end point, it will return CodeService instance.
+If you are not using endpoint, it will return `CodeService` instance.
 ```php
-<?php
-
     Code::type(2); 
     // Tsubasarcs\Recommendations\CodeService {#result: [], #times: 1, #type: 2, #length: 10};
-
 ```
 
 Example
 ```php
-<?php
-
     Code::type(2)->length(15)->times(2)->generate(); 
     // [["type" => 2, "code" => "tKqk6yo0v3CKiKO"], ["type" => 2, "code" => "meDBcyZSm6bjfRH"]];
-
 ```

--- a/config/recommendation.php
+++ b/config/recommendation.php
@@ -4,7 +4,7 @@ return [
         'name' => \Tsubasarcs\Recommendations\Recommendation::class,
         'code_column' => 'code',
     ],
-    'relation_model' => \Tsubasarcs\Recommendations\Tests\Illuminate\User::class,
+    'relation_model' => \Tsubasarcs\Recommendations\IlluminateUser::class,
     'default' => [
         'type' => 1,
         'length' => 10,

--- a/src/IlluminateUser.php
+++ b/src/IlluminateUser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tsubasarcs\Recommendations\Tests\Illuminate;
+namespace Tsubasarcs\Recommendations;
 
 use Illuminate\Database\Eloquent\Model;
 use Tsubasarcs\Recommendations\Recommendation;
 
-class User extends Model
+class IlluminateUser extends Model
 {
     protected $table = 'users';
 


### PR DESCRIPTION
The reason is, the config shouldn't exist any test directory belongs to the class.
Moving user class to the same level as Recommendation class is better.